### PR TITLE
Rewrite IpRange, update dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.65
+      - uses: dtolnay/rust-toolchain@1.70
       - run: cargo check
 
   test:
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.65
+      - uses: dtolnay/rust-toolchain@1.70
       - run: cargo test
 
   fmt:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.65
+      - uses: dtolnay/rust-toolchain@1.70
       - run: rustup component add rustfmt
       - run: cargo fmt --all -- --check
 
@@ -33,6 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.65
+      - uses: dtolnay/rust-toolchain@1.70
       - run: rustup component add clippy
       - run: cargo clippy -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -17,9 +17,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -38,9 +38,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "iptools"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "once_cell",
@@ -59,15 +59,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
@@ -87,27 +87,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -128,15 +128,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -151,9 +151,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -169,18 +169,18 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iptools"
-version = "0.2.5"
+version = "0.3.0"
 authors = ["Denis Avvakumov"]
 license = "MIT"
 readme = "README.md"
@@ -14,9 +14,9 @@ categories = ["algorithms", "network-programming"]
 edition = "2021"
 
 [dependencies]
-regex = "1.10.3"
+regex = "1.10.6"
 once_cell = "1.19.0"
-ahash = "0.8.7"
+ahash = "0.8.11"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This is a port of package [iptools](https://github.com/bd808/python-iptools) fro
 Add the following dependency to your Cargo manifest:
 ```
 [dependencies]
-iptools = "0.2.5"
+iptools = "0.3.0"
 ```
 
 ## Example of usage
 ```rust
-let first_range = IpRange::new("127.0.0.1/16", "").unwrap();
-let second_range = IpRange::new("127.0.0.1", "127.0.0.255").unwrap();
+let first_range = IpRange::<IPv4>::new("127.0.0.1/16", "").unwrap();
+let second_range = IpRange::<IPv4>::new("127.0.0.1", "127.0.0.255").unwrap();
 // Print range (tuple)
 println!("{:?} {:?}", first_range.get_range(), second_range.get_range());
 // Ip address range iterator
@@ -30,7 +30,7 @@ println!("{:?}", first_range.contains("127.0.0.3"));
 ```
 
 ## Supported Rust Versions
-Rust 1.65.0+
+Rust 1.70.0+
 
 ## License
 

--- a/src/iprange.rs
+++ b/src/iprange.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2022 Denis Avvakumov
 // Licensed under the MIT license,  https://opensource.org/licenses/MIT
 
-use crate::error::Error::{UnknownVersion, V4Subnet};
-use crate::error::Result;
+use crate::error::{Error, Result};
+use crate::iprange::Error::UnknownVersion;
 use crate::iprange::IpVer::*;
 use crate::ipv4;
 use crate::ipv6;
@@ -10,158 +10,181 @@ use std::hash::{Hash, Hasher};
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum IpVer {
-    IPV4,
-    IPV6,
-    IPVUnknown,
+    V4,
+    V6,
+    VUnknown,
 }
 
 #[derive(Debug, Clone)]
-pub struct IpRange {
-    ip_version: IpVer,
+pub struct IPv4 {
+    start_ip: u32,
+    end_ip: u32,
+    len: u32,
+    iter_ip: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct IPv6 {
     start_ip: u128,
     end_ip: u128,
-    length: u128,
+    len: u128,
     iter_ip: u128,
 }
 
-impl Iterator for IpRange {
-    type Item = String;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.iter_ip == self.end_ip {
-            return None;
-        }
-        self.iter_ip = match self.iter_ip.checked_add(1) {
-            Some(x) => x,
-            None => return None,
-        };
-        match self.ip_version {
-            IPV4 => Some(ipv4::long2ip(self.iter_ip as u32)),
-            IPV6 => Some(ipv6::long2ip(self.iter_ip, false)),
-            IPVUnknown => None,
+impl IPv4 {
+    fn new(start: u32, end: u32, iter_ip: u32) -> IPv4 {
+        IPv4 {
+            start_ip: start,
+            end_ip: end,
+            len: end - start + 1,
+            iter_ip,
         }
     }
 }
 
-impl Hash for IpRange {
+impl IPv6 {
+    fn new(start: u128, end: u128, iter_ip: u128) -> IPv6 {
+        IPv6 {
+            start_ip: start,
+            end_ip: end,
+            len: end - start + 1,
+            iter_ip,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IpRange<T> {
+    ip_version: IpVer,
+    ip_range: T,
+}
+
+impl Iterator for IpRange<IPv4> {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ip_range.iter_ip >= self.ip_range.end_ip {
+            return None;
+        }
+        self.ip_range.iter_ip = self.ip_range.iter_ip.checked_add(1)?;
+        Some(ipv4::long2ip(self.ip_range.iter_ip))
+    }
+}
+
+impl Iterator for IpRange<IPv6> {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ip_range.iter_ip >= self.ip_range.end_ip {
+            return None;
+        }
+        self.ip_range.iter_ip = self.ip_range.iter_ip.checked_add(1)?;
+        Some(ipv6::long2ip(self.ip_range.iter_ip, false))
+    }
+}
+
+impl Hash for IPv4 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.start_ip.hash(state);
         self.end_ip.hash(state);
     }
 }
 
-impl PartialEq for IpRange {
+impl Hash for IPv6 {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.start_ip.hash(state);
+        self.end_ip.hash(state);
+    }
+}
+
+impl PartialEq for IpRange<IPv4> {
     fn eq(&self, other: &Self) -> bool {
-        self.start_ip == other.start_ip && self.end_ip == other.end_ip
+        self.ip_range.start_ip == other.ip_range.start_ip
+            && self.ip_range.end_ip == other.ip_range.end_ip
     }
 }
 
-// Converts a string address to a numeric value
-fn _address2long(address: &str, ip_ver: &IpVer) -> Result<u128> {
-    match ip_ver {
-        IPV4 => ipv4::ip2long(address).map(|ip_long| ip_long as u128),
-        IPV6 => ipv6::ip2long(address),
-        IPVUnknown => Err(UnknownVersion()),
+impl PartialEq for IpRange<IPv6> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ip_range.start_ip == other.ip_range.start_ip
+            && self.ip_range.end_ip == other.ip_range.end_ip
     }
 }
 
-/// Range of ip addresses (IPV4, IPV6)
-/// Convert a CIDR notation address, ip address and subnet, tuple of ip addresses or start and end addresses into iterable object
-impl IpRange {
-    pub fn new(start: &str, end: &str) -> Result<IpRange> {
-        let mut start = start.to_string();
+fn address2long_v4(address: &str) -> Result<u32> {
+    ipv4::ip2long(address)
+}
+
+fn address2long_v6(address: &str) -> Result<u128> {
+    ipv6::ip2long(address)
+}
+
+impl IpRange<IPv4> {
+    pub fn new(start: &str, end: &str) -> Result<IpRange<IPv4>> {
         let mut end = end.to_string();
 
         if end.is_empty() {
-            end = start.clone();
+            end = start.to_string();
         }
 
-        let ip_ver = match (ipv4::validate_cidr(&start), ipv6::validate_cidr(&start)) {
-            (true, _) => {
-                let result = ipv4::cidr2block(&start)?;
-                start = result.0;
-                end = result.1;
-                IPV4
-            }
-            (_, true) => {
-                let result = ipv6::cidr2block(&start)?;
-                start = result.0;
-                end = result.1;
-                IPV6
-            }
-            _ => {
-                if ipv4::validate_subnet(&start) {
-                    let result = ipv4::subnet2block(&start).ok_or(V4Subnet())?;
-                    start = result.0;
-                    end = result.1;
-                    IPV4
-                } else if ipv4::validate_ip(&start) {
-                    IPV4
-                } else if ipv6::validate_ip(&start) {
-                    IPV6
-                } else {
-                    return Err(UnknownVersion());
-                }
-            }
+        let start_ip = if ipv4::validate_cidr(start) {
+            let tuple = ipv4::cidr2block(start)?;
+            address2long_v4(&tuple.0)?
+        } else {
+            address2long_v4(start)?
         };
 
-        let start_ip = _address2long(&start, &ip_ver)?;
-        let end_ip = _address2long(&end, &ip_ver)?;
+        let end_ip = if end.is_empty() {
+            start_ip
+        } else if ipv4::validate_cidr(&end) {
+            let tuple = ipv4::cidr2block(&end)?;
+            address2long_v4(&tuple.1)?
+        } else {
+            address2long_v4(&end)?
+        };
+
+        if start_ip > end_ip {
+            return Err(Error::V4Subnet());
+        }
 
         let iter_ip = start_ip.checked_sub(1).unwrap_or(start_ip);
 
         Ok(IpRange {
-            ip_version: ip_ver,
-            start_ip,
-            end_ip,
-            length: end_ip - start_ip + 1,
-            iter_ip,
+            ip_version: V4,
+            ip_range: IPv4::new(start_ip, end_ip, iter_ip),
         })
     }
 
-    /// Get current range as pair of strings
     pub fn get_range(&self) -> Option<(String, String)> {
-        match self.ip_version {
-            IPV4 => Some((
-                ipv4::long2ip(self.start_ip as u32),
-                ipv4::long2ip(self.end_ip as u32),
-            )),
-            IPV6 => Some((
-                ipv6::long2ip(self.start_ip, false),
-                ipv6::long2ip(self.end_ip, false),
-            )),
-            _ => None,
-        }
-    }
-    /// Get current range as pair of u128
-    pub fn get_range_long(&self) -> (u128, u128) {
-        (self.start_ip, self.end_ip)
+        Some((
+            ipv4::long2ip(self.ip_range.start_ip),
+            ipv4::long2ip(self.ip_range.end_ip),
+        ))
     }
 
-    /// Get version for current range
+    pub fn get_range_long(&self) -> (u32, u32) {
+        (self.ip_range.start_ip, self.ip_range.end_ip)
+    }
+
     pub fn get_version(&self) -> IpVer {
         self.ip_version.clone()
     }
 
-    /// Get length for inited range
-    pub fn len(&self) -> u128 {
-        self.length
+    pub fn len(&self) -> u32 {
+        self.ip_range.len
     }
 
-    /// Check if length is zero
     pub fn is_empty(&self) -> bool {
-        self.length == 0
+        self.ip_range.len == 0
     }
 
-    /// Get length of current IP range
-    pub fn len_cur(&self) -> u128 {
-        if self.iter_ip == self.end_ip {
-            return self.end_ip - self.iter_ip + 1;
+    pub fn len_cur(&self) -> u32 {
+        if self.ip_range.iter_ip == self.ip_range.end_ip {
+            return self.ip_range.end_ip - self.ip_range.iter_ip + 1;
         }
-        self.end_ip - self.iter_ip
+        self.ip_range.end_ip - self.ip_range.iter_ip
     }
 
-    /// Check that the address is in the current range
     pub fn contains(&self, ip: &str) -> Result<bool> {
         let mut is_valid = false;
         let mut is_range = false;
@@ -171,21 +194,21 @@ impl IpRange {
         if ipv4::validate_cidr(ip) {
             is_range = true;
             let tuple = ipv4::cidr2block(ip)?;
-            start_ip = _address2long(&tuple.0, &IPV4)?;
-            end_ip = _address2long(&tuple.1, &IPV4)?;
+            start_ip = address2long_v4(&tuple.0)? as u128;
+            end_ip = address2long_v4(&tuple.1)? as u128;
             is_valid = true;
         } else if ipv6::validate_cidr(ip) {
             is_valid = true;
             is_range = true;
             let tuple = ipv6::cidr2block(ip)?;
-            start_ip = _address2long(&tuple.0, &IPV6)?;
-            end_ip = _address2long(&tuple.1, &IPV6)?;
+            start_ip = address2long_v6(&tuple.0)?;
+            end_ip = address2long_v6(&tuple.1)?;
         } else if ipv6::validate_ip(ip) {
             is_valid = true;
-            addr = _address2long(ip, &IPV6)?;
+            addr = address2long_v6(ip)?;
         } else if ipv4::validate_ip(ip) {
             is_valid = true;
-            addr = _address2long(ip, &IPV4)?;
+            addr = address2long_v4(ip)? as u128;
         }
 
         if !is_valid {
@@ -194,77 +217,204 @@ impl IpRange {
 
         if !is_range {
             match self.ip_version {
-                IPV4 => {
-                    Ok(self.start_ip as u32 <= addr as u32 && addr as u32 <= self.end_ip as u32)
+                V4 => Ok(
+                    self.ip_range.start_ip <= addr as u32 && addr as u32 <= self.ip_range.end_ip
+                ),
+                V6 => {
+                    Ok(self.ip_range.start_ip as u128 <= addr
+                        && addr <= self.ip_range.end_ip as u128)
                 }
-                IPV6 => Ok(self.start_ip <= addr && addr <= self.end_ip),
-                IPVUnknown => Err(UnknownVersion()),
+                VUnknown => Err(UnknownVersion()),
             }
         } else {
             match self.ip_version {
-                IPV4 => Ok(self.start_ip as u32 <= start_ip as u32
-                    && start_ip as u32 <= self.end_ip as u32
-                    && end_ip as u32 <= self.end_ip as u32),
-                IPV6 => Ok(self.start_ip <= start_ip
-                    && start_ip <= self.end_ip
-                    && end_ip <= self.end_ip),
-                IPVUnknown => Err(UnknownVersion()),
+                V4 => Ok(self.ip_range.start_ip <= start_ip as u32
+                    && start_ip as u32 <= self.ip_range.end_ip
+                    && end_ip as u32 <= self.ip_range.end_ip),
+                V6 => Ok(self.ip_range.start_ip as u128 <= start_ip
+                    && start_ip <= self.ip_range.end_ip as u128
+                    && end_ip <= self.ip_range.end_ip as u128),
+                VUnknown => Err(UnknownVersion()),
             }
         }
     }
 
-    /// Check if ip addr is reserved/private for IPV4
-    pub fn is_reserved_ipv4(ip: &str) -> Result<bool> {
+    fn is_reserved_ipv4(ip: &str) -> Result<bool> {
         for i in ipv4::RESERVED_RANGES.iter() {
-            if IpRange::new(i, "")?.contains(ip)? {
+            if IpRange::<IPv4>::new(i, "")?.contains(ip)? {
                 return Ok(true);
             }
         }
         Ok(false)
     }
 
-    /// Check if ip addr is reserved/private for IPV6
-    pub fn is_reserved_ipv6(ip: &str) -> Result<bool> {
-        for i in ipv6::RESERVED_RANGES.iter() {
-            if IpRange::new(i, "")?.contains(ip)? {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
-    /// Check if ip addr is reserved/private for IPV4 and IPV6
     pub fn is_reserved(ip: &str) -> Result<bool> {
-        Ok(IpRange::is_reserved_ipv4(ip)? || IpRange::is_reserved_ipv6(ip)?)
+        IpRange::is_reserved_ipv4(ip)
+    }
+}
+
+impl IpRange<IPv6> {
+    pub fn new(start: &str, end: &str) -> Result<IpRange<IPv6>> {
+        let mut end = end.to_string();
+
+        if end.is_empty() {
+            end = start.to_string();
+        }
+
+        let start_ip = if ipv6::validate_cidr(start) {
+            let tuple = ipv6::cidr2block(start)?;
+            address2long_v6(&tuple.0)?
+        } else {
+            address2long_v6(start)?
+        };
+
+        let end_ip = if end.is_empty() {
+            start_ip
+        } else if ipv6::validate_cidr(&end) {
+            let tuple = ipv6::cidr2block(&end)?;
+            address2long_v6(&tuple.1)?
+        } else {
+            address2long_v6(&end)?
+        };
+
+        if start_ip > end_ip {
+            return Err(Error::V4Subnet());
+        }
+
+        let iter_ip = start_ip.checked_sub(1).unwrap_or(start_ip);
+
+        Ok(IpRange {
+            ip_version: V6,
+            ip_range: IPv6::new(start_ip, end_ip, iter_ip),
+        })
+    }
+
+    pub fn get_range(&self) -> Option<(String, String)> {
+        Some((
+            ipv6::long2ip(self.ip_range.start_ip, false),
+            ipv6::long2ip(self.ip_range.end_ip, false),
+        ))
+    }
+
+    pub fn get_range_long(&self) -> (u128, u128) {
+        (self.ip_range.start_ip, self.ip_range.end_ip)
+    }
+
+    pub fn get_version(&self) -> IpVer {
+        self.ip_version.clone()
+    }
+
+    pub fn len(&self) -> u128 {
+        self.ip_range.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ip_range.len == 0
+    }
+
+    pub fn len_cur(&self) -> u128 {
+        if self.ip_range.iter_ip == self.ip_range.end_ip {
+            return self.ip_range.end_ip - self.ip_range.iter_ip + 1;
+        }
+        self.ip_range.end_ip - self.ip_range.iter_ip
+    }
+
+    pub fn contains(&self, ip: &str) -> Result<bool> {
+        let mut is_valid = false;
+        let mut is_range = false;
+        let mut addr = 0u128;
+        let mut start_ip = 0u128;
+        let mut end_ip = 0u128;
+        if ipv4::validate_cidr(ip) {
+            is_range = true;
+            let tuple = ipv4::cidr2block(ip)?;
+            start_ip = address2long_v4(&tuple.0)? as u128;
+            end_ip = address2long_v4(&tuple.1)? as u128;
+            is_valid = true;
+        } else if ipv6::validate_cidr(ip) {
+            is_valid = true;
+            is_range = true;
+            let tuple = ipv6::cidr2block(ip)?;
+            start_ip = address2long_v6(&tuple.0)?;
+            end_ip = address2long_v6(&tuple.1)?;
+        } else if ipv6::validate_ip(ip) {
+            is_valid = true;
+            addr = address2long_v6(ip)?;
+        } else if ipv4::validate_ip(ip) {
+            is_valid = true;
+            addr = address2long_v4(ip)? as u128;
+        }
+
+        if !is_valid {
+            return Err(UnknownVersion());
+        }
+
+        if !is_range {
+            match self.ip_version {
+                V4 => Ok(self.ip_range.start_ip as u32 <= addr as u32
+                    && addr as u32 <= self.ip_range.end_ip as u32),
+                V6 => Ok(self.ip_range.start_ip <= addr && addr <= self.ip_range.end_ip),
+                VUnknown => Err(UnknownVersion()),
+            }
+        } else {
+            match self.ip_version {
+                V4 => Ok(self.ip_range.start_ip as u32 <= start_ip as u32
+                    && start_ip as u32 <= self.ip_range.end_ip as u32
+                    && end_ip as u32 <= self.ip_range.end_ip as u32),
+                V6 => Ok(self.ip_range.start_ip <= start_ip
+                    && start_ip <= self.ip_range.end_ip
+                    && end_ip <= self.ip_range.end_ip),
+                VUnknown => Err(UnknownVersion()),
+            }
+        }
+    }
+
+    fn is_reserved_ipv6(ip: &str) -> Result<bool> {
+        for i in ipv6::RESERVED_RANGES.iter() {
+            if IpRange::<IPv6>::new(i, "")?.contains(ip)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    pub fn is_reserved(ip: &str) -> Result<bool> {
+        IpRange::is_reserved_ipv6(ip)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::iprange::IpRange;
-    use crate::iprange::IpVer::{IPV4, IPV6};
+    use crate::iprange::IpVer::{V4, V6};
+    use crate::iprange::{IPv4, IPv6, IpRange};
 
     use pretty_assertions::assert_eq;
 
     #[test]
     fn test_initialization() {
-        assert_eq!(IpRange::new("127.0.0.1", "").unwrap().get_version(), IPV4);
         assert_eq!(
-            IpRange::new("127.0.0.2", "127.255.255.255")
+            IpRange::<IPv4>::new("127.0.0.1", "").unwrap().get_version(),
+            V4
+        );
+        assert_eq!(
+            IpRange::<IPv4>::new("127.0.0.2", "127.255.255.255")
                 .unwrap()
                 .get_version(),
-            IPV4
+            V4
         );
-        assert_eq!(IpRange::new("::1", "::2").unwrap().get_version(), IPV6);
+        assert_eq!(
+            IpRange::<IPv6>::new("::1", "::2").unwrap().get_version(),
+            V6
+        );
 
-        assert_eq!(IpRange::new("::1", "").unwrap().get_version(), IPV6);
+        assert_eq!(IpRange::<IPv6>::new("::1", "").unwrap().get_version(), V6);
     }
 
     #[test]
     fn test_get_range() {
-        let x = IpRange::new("127.0.0.1/24", "").unwrap();
-        let xx = IpRange::new("255.255.1.1/16", "").unwrap();
-        let xxx = IpRange::new("127.0.0.1", "127.0.0.255").unwrap();
+        let x = IpRange::<IPv4>::new("127.0.0.1/24", "").unwrap();
+        let xx = IpRange::<IPv4>::new("255.255.1.1/16", "").unwrap();
+        let xxx = IpRange::<IPv4>::new("127.0.0.1", "127.0.0.255").unwrap();
         assert_eq!(
             x.get_range(),
             Some(("127.0.0.0".to_string(), "127.0.0.255".to_string()))
@@ -281,25 +431,34 @@ mod tests {
 
     #[test]
     fn test_len() {
-        assert_eq!(IpRange::new("127.0.0.3", "127.0.0.4").unwrap().len(), 2);
         assert_eq!(
-            IpRange::new("127.0.0.3", "127.0.255.4").unwrap().len(),
+            IpRange::<IPv4>::new("127.0.0.3", "127.0.0.4")
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            IpRange::<IPv4>::new("127.0.0.3", "127.0.255.4")
+                .unwrap()
+                .len(),
             65282
         );
         assert_eq!(
-            IpRange::new("127.0.0.1", "255.255.255.255").unwrap().len(),
+            IpRange::<IPv4>::new("127.0.0.1", "255.255.255.255")
+                .unwrap()
+                .len(),
             2164260863
         );
-        assert_eq!(IpRange::new("::1", "::2").unwrap().len(), 2);
+        assert_eq!(IpRange::<IPv6>::new("::1", "::2").unwrap().len(), 2);
         assert_eq!(
-            IpRange::new("fe80::/10", "").unwrap().len(),
+            IpRange::<IPv6>::new("fe80::/10", "").unwrap().len(),
             332306998946228968225951765070086144
         );
     }
 
     #[test]
     fn test_contains() {
-        let range = IpRange::new("127.0.0.3", "127.0.0.5").unwrap();
+        let range = IpRange::<IPv4>::new("127.0.0.3", "127.0.0.5").unwrap();
         assert_eq!(range.contains("127.0.0.3").unwrap(), true);
         assert_eq!(range.contains("127.0.0.4").unwrap(), true);
         assert_eq!(range.contains("127.0.0.5").unwrap(), true);
@@ -313,48 +472,48 @@ mod tests {
     #[test]
     fn test_equal() {
         assert_eq!(
-            IpRange::new("127.0.0.0/8", "").unwrap(),
-            IpRange::new("127.0.0.0", "127.255.255.255").unwrap()
+            IpRange::<IPv4>::new("127.0.0.0/8", "").unwrap(),
+            IpRange::<IPv4>::new("127.0.0.0", "127.255.255.255").unwrap()
         );
         assert_ne!(
-            IpRange::new("127.0.0.0/8", "").unwrap(),
-            IpRange::new("127.0.0.0", "127.255.255.254").unwrap()
+            IpRange::<IPv4>::new("127.0.0.0/8", "").unwrap(),
+            IpRange::<IPv4>::new("127.0.0.0", "127.255.255.254").unwrap()
         );
         assert_eq!(
-            IpRange::new("::1/64", "").unwrap(),
-            IpRange::new("::", "::ffff:ffff:ffff:ffff").unwrap()
+            IpRange::<IPv6>::new("::1/64", "").unwrap(),
+            IpRange::<IPv6>::new("::", "::ffff:ffff:ffff:ffff").unwrap()
         );
         assert_ne!(
-            IpRange::new("::1/64", "").unwrap(),
-            IpRange::new("::2", "::ffff:ffff:ffff:ffff").unwrap()
+            IpRange::<IPv6>::new("::1/64", "").unwrap(),
+            IpRange::<IPv6>::new("::2", "::ffff:ffff:ffff:ffff").unwrap()
         );
     }
 
     #[test]
     fn test_next() {
-        let mut a = IpRange::new("127/31", "").unwrap();
+        let mut a = IpRange::<IPv4>::new("127/31", "").unwrap();
         assert_eq!(a.next().unwrap(), "127.0.0.0");
         assert_eq!(a.next().unwrap(), "127.0.0.1");
         assert_eq!(a.next(), None);
-        let mut b = IpRange::new("::1", "::3").unwrap();
+        let mut b = IpRange::<IPv6>::new("::1", "::3").unwrap();
         assert_eq!(b.next().unwrap(), "::1");
         assert_eq!(b.next().unwrap(), "::2");
         assert_eq!(b.next().unwrap(), "::3");
         assert_eq!(b.next(), None);
-        let mut c = IpRange::new("255.255.255.255", "").unwrap();
+        let mut c = IpRange::<IPv4>::new("255.255.255.255", "").unwrap();
         assert_eq!(c.next().unwrap(), "255.255.255.255");
         assert_eq!(c.next(), None);
     }
 
     #[test]
     fn test_len_cur() {
-        let mut a = IpRange::new("127/31", "").unwrap();
+        let mut a = IpRange::<IPv4>::new("127/31", "").unwrap();
         assert_eq!(a.len_cur(), 2);
         a.next();
         assert_eq!(a.len_cur(), 1);
         a.next();
         assert_eq!(a.len_cur(), 1);
-        let mut b = IpRange::new("::1", "::3").unwrap();
+        let mut b = IpRange::<IPv6>::new("::1", "::3").unwrap();
         assert_eq!(b.len_cur(), 3);
         b.next();
         b.next();
@@ -362,7 +521,7 @@ mod tests {
         b.next();
         b.next();
         assert_eq!(b.len_cur(), 1);
-        let mut c = IpRange::new("255.255.255.255", "").unwrap();
+        let mut c = IpRange::<IPv4>::new("255.255.255.255", "").unwrap();
         assert_eq!(c.len_cur(), 1);
         c.next();
         assert_eq!(c.len_cur(), 1);
@@ -370,27 +529,39 @@ mod tests {
 
     #[test]
     fn test_is_reserved() {
-        assert_eq!(IpRange::is_reserved("127.0.0.1").unwrap(), true);
-        assert_eq!(IpRange::is_reserved(crate::ipv4::BROADCAST).unwrap(), true);
-        assert_eq!(IpRange::is_reserved(crate::ipv4::LOOPBACK).unwrap(), true);
+        assert_eq!(IpRange::<IPv4>::is_reserved("127.0.0.1").unwrap(), true);
         assert_eq!(
-            IpRange::is_reserved(crate::ipv4::IPV6_TO_IPV4_RELAY).unwrap(),
+            IpRange::<IPv4>::is_reserved(crate::ipv4::BROADCAST).unwrap(),
             true
         );
-        assert_eq!(IpRange::is_reserved("8.8.8.8").unwrap(), false);
-        assert_eq!(IpRange::is_reserved(crate::ipv6::LOOPBACK).unwrap(), true);
+        assert_eq!(
+            IpRange::<IPv4>::is_reserved(crate::ipv4::LOOPBACK).unwrap(),
+            true
+        );
+        assert_eq!(
+            IpRange::<IPv4>::is_reserved(crate::ipv4::IPV6_TO_IPV4_RELAY).unwrap(),
+            true
+        );
+        assert_eq!(IpRange::<IPv4>::is_reserved("8.8.8.8").unwrap(), false);
+        assert_eq!(
+            IpRange::<IPv6>::is_reserved(crate::ipv6::LOOPBACK).unwrap(),
+            true
+        );
 
-        assert_eq!(IpRange::is_reserved("123456").ok(), None);
+        assert_eq!(IpRange::<IPv4>::is_reserved("123456").ok(), None);
+        assert_eq!(IpRange::<IPv6>::is_reserved("123456").ok(), None);
     }
 
     #[test]
     fn test_constructor() {
-        assert_eq!(IpRange::new("Bolognese", "").ok(), None);
+        assert_eq!(IpRange::<IPv4>::new("Bolognese", "").ok(), None);
+        assert_eq!(IpRange::<IPv6>::new("Bolognese", "").ok(), None);
     }
 
     #[test]
     #[should_panic]
     fn test_should_panic() {
-        IpRange::new("12345678", "").unwrap();
+        IpRange::<IPv4>::new("12345678", "").unwrap();
+        IpRange::<IPv6>::new("12345678", "").unwrap();
     }
 }

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -42,7 +42,7 @@ pub static RESERVED_RANGES: Lazy<Vec<&str>> = Lazy::new(|| {
 
 #[allow(dead_code)]
 /// Last ip
-pub const MAX_IP: u32 = std::u32::MAX;
+pub const MAX_IP: u32 = u32::MAX;
 
 /// First ip
 pub const MIN_IP: u32 = 0;
@@ -406,7 +406,7 @@ fn _block_from_ip_and_prefix(ip: u32, prefix: u32) -> (String, String) {
         .checked_shl(shift)
         .unwrap_or(0);
 
-    let mut mask = std::u32::MAX;
+    let mut mask = u32::MAX;
     if let Some(shift) = 1u32.checked_shl(shift) {
         if let Some(sub) = shift.checked_sub(1) {
             mask = sub;

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -34,7 +34,7 @@ static RE_RFC1924: Lazy<&Regex> = Lazy::new(|| {
 const _RFC1924_REV: bool = true;
 
 /// Last ip
-pub const MAX_IP: u128 = std::u128::MAX;
+pub const MAX_IP: u128 = u128::MAX;
 
 /// First ip
 pub const MIN_IP: u128 = 0;
@@ -392,7 +392,7 @@ pub fn cidr2block(cidr: &str) -> Result<(String, String)> {
         .checked_shl(shift)
         .unwrap_or(0);
 
-    let mut mask = std::u128::MAX;
+    let mut mask = u128::MAX;
     if let Some(shift) = 1u128.checked_shl(shift) {
         if let Some(sub) = shift.checked_sub(1) {
             mask = sub;


### PR DESCRIPTION
1. Introduce new structs IPv4, IPv6 to reduce storage usage for IPv4.
2. Update dependencies to the latest version.
3. Up MSRV to 1.70+